### PR TITLE
Fix footer on pages < 100vh

### DIFF
--- a/components/Footer.module.scss
+++ b/components/Footer.module.scss
@@ -1,5 +1,7 @@
 .footer {
   margin-top: 5em;
+  position: absolute;
+  inset: auto 0 0;
 
   &_grid {
     display: grid;


### PR DESCRIPTION
This ensures the footer is always at the bottom of the page, even when the page is less than the height of the viewport